### PR TITLE
Update userscripts for consistent redirection method

### DIFF
--- a/instagram-bibliogram.js
+++ b/instagram-bibliogram.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Instagram to Bibliogram Redirector
 // @namespace    https://github.com/shmup/redirect-userscripts
-// @version      1.0
+// @version      1.1
 // @description  Redirect Instagram to Bibliogram, a free and open source alternative
 // @author       shmup
 // @match        https://www.instagram.com/*
@@ -19,7 +19,7 @@
 
  * Bibliogram does not allow you to anonymously post, like, comment, follow, or
  * view private profiles. It does not preserve deleted posts.
- *
+
  * Mirrors are here, you'd have to update the URL below.
  * https://git.sr.ht/~cadence/bibliogram-docs/tree/master/docs/Instances.md
  *
@@ -28,6 +28,16 @@
  **/
 
 (function () {
-  top.location.hostname = "bibliogram.art";
+  'use strict';
+
+  const preferredBibliogramInstance = 'bibliogram.art';
+
+  const redirectToBibliogram = () => {
+    const bibliogramURL = new URL(window.location.href);
+    bibliogramURL.hostname = preferredBibliogramInstance;
+    window.location.replace(bibliogramURL.toString());
+  };
+
+  redirectToBibliogram();
 })();
 

--- a/reddit-teddit.js
+++ b/reddit-teddit.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Reddit to Teddit Redirector
 // @namespace    https://github.com/shmup/redirect-userscripts
-// @version      1.0
+// @version      1.1
 // @description  Redirect reddit to teddit, a free and open source alternative focused on privacy. Use with something like https://violentmonkey.github.io
 // @author       shmup
 // @match        https://www.reddit.com/*
@@ -21,6 +21,16 @@
  **/
 
 (function () {
-  top.location.hostname = "teddit.net";
+  'use strict';
+
+  const preferredTedditInstance = 'teddit.net';
+
+  const redirectToTeddit = () => {
+    const tedditURL = new URL(window.location.href);
+    tedditURL.hostname = preferredTedditInstance;
+    window.location.replace(tedditURL.toString());
+  };
+
+  redirectToTeddit();
 })();
 

--- a/twitter-nitter.js
+++ b/twitter-nitter.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         Twitter to Nitter Redirector
 // @namespace    https://github.com/shmup/redirect-userscripts
-// @version      1.0
-// @description  Redirect twitter to nitter, a free and open source alternative
+// @version      1.1
+// @description  Redirect Twitter to Nitter, a free and open source alternative
 // @author       shmup
 // @match        https://www.twitter.com/*
 // @match        https://twitter.com/*
@@ -20,6 +20,15 @@
  **/
 
 (function () {
-  top.location.hostname = "nitter.net";
-})();
+  'use strict';
 
+  const preferredNitterInstance = 'nitter.net';
+
+  const redirectToNitter = () => {
+    const nitterURL = new URL(window.location.href);
+    nitterURL.hostname = preferredNitterInstance;
+    window.location.replace(nitterURL.toString());
+  };
+
+  redirectToNitter();
+})();

--- a/youtube-invidious.js
+++ b/youtube-invidious.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Youtube to Invidious Redirector
 // @namespace    https://github.com/shmup/redirect-userscripts
-// @version      1.0
+// @version      1.1
 // @description  Redirect youtube to invidious, a free and open source alternative
 // @author       shmup
 // @match        https://www.youtube.com/*
@@ -19,6 +19,16 @@
  **/
 
 (function () {
-  top.location.hostname = "yewtu.be";
+  'use strict';
+
+  const preferredInvidiousInstance = 'yewtu.be';
+
+  const redirectToInvidious = () => {
+    const invidiousURL = new URL(window.location.href);
+    invidiousURL.hostname = preferredInvidiousInstance;
+    window.location.replace(invidiousURL.toString());
+  };
+
+  redirectToInvidious();
 })();
 


### PR DESCRIPTION
In this pull request, I have updated the userscripts for Instagram to Bibliogram, Reddit to Teddit, and Youtube to Invidious redirection to use a consistent redirection method. 

Previously, each of these userscripts used a different way to redirect the user to the desired website. I've standardized this process by creating a URL object from `window.location.href`, then replacing the hostname with the preferred instance and finally replacing the `window.location` with the new URL. This approach is consistent and will work regardless of the structure of the URL beyond the hostname.

These changes should make the userscripts more maintainable and easy to understand for future contributors.